### PR TITLE
Fix rambo.upload.maximum_size

### DIFF
--- a/rambo/boards.txt
+++ b/rambo/boards.txt
@@ -13,7 +13,7 @@ rambo.pid.0=0x0001
 
 rambo.upload.tool=arduino:avrdude
 rambo.upload.protocol=wiring
-rambo.upload.maximum_size=258048
+rambo.upload.maximum_size=253952
 rambo.upload.speed=115200
 
 rambo.bootloader.low_fuses=0xFF


### PR DESCRIPTION
rambo.bootloader.high_fuses is specifying bootloader size to be 4096 words, this means 8192 bytes. upload.maximum_size should be 262144 - 8192 = 253952 bytes.